### PR TITLE
Update URL & spelling in index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,11 +2,11 @@
 python-bioformats: read and write life sciences image file formats
 ===================================================================
 
-The python-bioformats package is an interface to the `Bioformats
-<http://loci.wisc.edu/software/bio-formats>`_ library for reading and
-writing life sciences image file formats.
+The python-bioformats package is an interface to the `Bio-Formats
+<http://www.openmicroscopy.org/site/products/bio-formats>`_ library
+for reading and writing life sciences image file formats.
 
-Because Bioformats is a Java library, python-bioformats uses
+Because Bio-Formats is a Java library, python-bioformats uses
 python-javabridge to start and interact with a Java virtual machine.
 
 Python-bioformats and python-javabridge were developed for and are


### PR DESCRIPTION
The documentation under http://loci.wisc.edu/software/bio-formats
now directs to pages under http://www.openmicroscopy.org/site/support/bio-formats
and the over all landing page is http://www.openmicroscopy.org/site/products/bio-formats.
