### PR TITLE
Jar update

### DIFF
--- a/bioformats/__init__.py
+++ b/bioformats/__init__.py
@@ -22,6 +22,8 @@ from . import formatwriter as _formatwriter
 
 _jars_dir = os.path.join(os.path.dirname(__file__), 'jars')
 
+JAR_VERSION = '5.0.6'
+
 JARS = javabridge.JARS + [os.path.realpath(os.path.join(_jars_dir, name + '.jar'))
                           for name in ['loci_tools']]
 """List of directories, jar files, and zip files that should be added

--- a/bioformats/formatreader.py
+++ b/bioformats/formatreader.py
@@ -98,9 +98,10 @@ def make_iformat_reader_class():
         getDimensionOrder = jutil.make_method('getDimensionOrder',
                                               '()Ljava/lang/String;',
                                               'Return the dimension order as a five-character string, e.g. "XYCZT"')
-        getMetadata = jutil.make_method('getMetadata',
+        getGlobalMetadata = jutil.make_method('getGlobalMetadata',
                                         '()Ljava/util/Hashtable;',
-                                        'Obtains the hashtable containing the metadata field/value pairs')
+                                        'Obtains the hashtable containing the global metadata field/value pairs')
+        getMetadata = getGlobalMetadata
         getMetadataValue = jutil.make_method('getMetadataValue',
                                              '(Ljava/lang/String;)'
                                              'Ljava/lang/Object;',


### PR DESCRIPTION
Following https://github.com/CellProfiler/python-bioformats/issues/19, here is a PR for the update of loci_tools.jar. I did the unittests, and it appears that all but one pass.

`test_02_01_make_image_reader` gives an error connected to the fact that `loci.formats.ImageReader.getMetadata` does not exist in loci 5.0.6. Instead, `loci.formats.ImageReader.getGlobalMetadata` can be used. I proposed a change in `formatreader.py` that covers this and with this change, all unittests pass.

Please let me know what you think about this, or edit freely.