### PR TITLE
Attempt to add Travis CI support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,18 @@
+[run]
+branch = True
+erase = True
+package = bioformats
+[report]
+exclude_lines =
+    # Ignore continue statement in code as it can't be detected as covered
+    # due to an optimization by the Python interpreter. See coverage issue
+    # ( https://bitbucket.org/ned/coveragepy/issue/198/continue-marked-as-not-covered )
+    # and Python issue ( http://bugs.python.org/issue2506 ).
+    continue
+
+    # Ignore coverage of code that requires the module to be executed.
+    if __name__ == .__main__.:
+omit =
+    */python?.?/*
+    */site-packages/*
+    *tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+language: java
+env:
+   - PYTHON_VERSION="2.7"
+before_install:
+   # Get the tag if it wasn't provided. Travis doesn't provide this if it isn't a tagged build.
+   - if [ -z $TRAVIS_TAG ]; then TRAVIS_TAG=`git tag --contains` ; fi
+   - echo $TRAVIS_TAG
+   # Move out of git directory to build root.
+   - cd ../..
+   - pwd
+install:
+   # Download and configure conda.
+   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+   - bash miniconda.sh -b -p $HOME/miniconda
+   - export PATH="$HOME/miniconda/bin:$PATH"
+   - conda config --set always_yes yes
+   - conda config --set show_channel_urls True
+   - source activate root
+   # Install basic conda dependencies.
+   - touch $HOME/miniconda/conda-meta/pinned
+   - echo "conda-build ==1.16.0" >> $HOME/miniconda/conda-meta/pinned
+   - conda update --all
+   - conda install conda-build
+   # Setup environment for testing and install all dependencies and our package.
+   - cd $TRAVIS_REPO_SLUG
+   - conda create --use-local -n testenv python=$PYTHON_VERSION
+   - source activate testenv
+   - conda install numpy
+   - python setup.py install
+   # Install sphinx to build documentation.
+   - conda install sphinx
+   # Install coverage and coveralls to generate and submit test coverage results for coveralls.io.
+   - echo "coverage 3.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
+   - conda install nose
+   - conda install coverage
+   - pip install coveralls
+   # Clean up downloads as there are quite a few and they waste space/memory.
+   - conda clean -tipsy
+   - rm -rfv $HOME/.cache/pip
+script:
+   # Run tests.
+   - python nosetests.py
+#after_success:
+   # Submit results to coveralls.io.
+   #- coveralls
+# Use container format for TravisCI for quicker startup and builds.
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ install:
 script:
    # Run tests.
    - python nosetests.py
-#after_success:
+after_success:
    # Submit results to coveralls.io.
-   #- coveralls
+   - coveralls
 # Use container format for TravisCI for quicker startup and builds.
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,10 @@ install:
 script:
    # Run tests.
    - python nosetests.py
+   # Build docs.
+   - cd docs
+   - make html
+   - cd ..
 #after_success:
    # Submit results to coveralls.io.
    #- coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ install:
 script:
    # Run tests.
    - python nosetests.py
-after_success:
+#after_success:
    # Submit results to coveralls.io.
-   - coveralls
+   #- coveralls
 # Use container format for TravisCI for quicker startup and builds.
 sudo: false

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [nosetests]
 with-javabridge = True
 classpath = bioformats/jars/loci_tools.jar
+with-coverage = 1
 
 [build_sphinx]
 source-dir = docs/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,6 @@
 [nosetests]
 with-javabridge = True
 classpath = bioformats/jars/loci_tools.jar
-with-coverage = 1
 
 [build_sphinx]
 source-dir = docs/


### PR DESCRIPTION
How this works.

* Try to handle Python and related dependencies with [`conda`]( http://conda.pydata.org/docs/ ). Makes it really easy to install `numpy` and the sort. Also, uses binaries so it is really fast (no build time). Usually, has recent versions.
* Uses a Java language environment. It is needed for some things in here anyways. Also, the Travis Python environment would be replaced with `conda`'s so we don't care about it.
* Use `pip` to install the latest `python-javabridge`. Easy to do. Likely what someone will do when installing themselves.
* Builds the `sphinx` docs with the `html` target. Just verifies the `docs` can still be built. May provide elucidating warnings in-case somebody isn't following correct syntax.
* Provides some coverage setting. Could be used to report to [coveralls.io]( https://coveralls.io/ ) given some tweaks to `python-javabridge`.