### PR TITLE
Shim to pip install in python2+3 (#56)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,52 +1,15 @@
-language: java
-env:
-   - PYTHON_VERSION="2.7"
-   - PYTHON_VERSION="3.5"
-before_install:
-   # Get the tag if it wasn't provided. Travis doesn't provide this if it isn't a tagged build.
-   - if [ -z $TRAVIS_TAG ]; then TRAVIS_TAG=`git tag --contains` ; fi
-   - echo $TRAVIS_TAG
-   # Move out of git directory to build root.
-   - cd ../..
-   - pwd
-install:
-   # Download and configure conda.
-   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-   - bash miniconda.sh -b -p $HOME/miniconda
-   - export PATH="$HOME/miniconda/bin:$PATH"
-   - conda config --set always_yes yes
-   - conda config --set show_channel_urls True
-   - source activate root
-   # Install basic conda dependencies.
-   - touch $HOME/miniconda/conda-meta/pinned
-   - echo "conda-build ==1.16.0" >> $HOME/miniconda/conda-meta/pinned
-   - conda update --all
-   - conda install conda-build
-   # Setup environment for testing and install all dependencies and our package.
-   - cd $TRAVIS_REPO_SLUG
-   - conda create --use-local -n testenv python=$PYTHON_VERSION
-   - source activate testenv
-   - conda install numpy
-   - python setup.py install
-   # Install sphinx to build documentation.
-   - conda install sphinx
-   # Install coverage and coveralls to generate and submit test coverage results for coveralls.io.
-   - echo "coverage 3.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
-   - conda install nose
-   - conda install coverage
-   - pip install coveralls
-   # Clean up downloads as there are quite a few and they waste space/memory.
-   - conda clean -tipsy
-   - rm -rfv $HOME/.cache/pip
-script:
-   # Run tests.
-   - python nosetests.py
-   # Build docs.
-   - cd docs
-   - make html
-   - cd ..
-#after_success:
-   # Submit results to coveralls.io.
-   #- coveralls
-# Use container format for TravisCI for quicker startup and builds.
+language: python
+python:
+  - "2.7"
+  - "3.5"
 sudo: false
+notifications:
+  email: false
+install:
+  - pip install --upgrade pip wheel
+  - pip install --upgrade numpy
+  - pip install sphinx
+  - pip install .
+script:
+  - nosetests
+  - cd docs && make html

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,13 @@ install:
 script:
   - nosetests
   - cd docs && make html
+deploy:
+  provider: pypi
+  user: mcquin
+  password:
+    secure: PrFX2wJrhchChzJD8DX+q7q9UK9zrxl0CN3AdT8kBEIAxzVpM+jCS0Znt7yPHipNjhhvCPtcP2HqmkKuV3o4EgGb/E7BORbKnvBmnLVPcAOpBJXSGxqSXctmPUDlV3FF6Vi2MSTzOIcAPBSqQEB9HBtEUYO34gu2R0dwC3LdrVM=
+  on:
+    tags: true
+    distributions: sdist bdist_wheel
+    repo: CellProfiler/python-bioformats
+  skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - pip install .
 script:
   - nosetests
-  - cd docs && make html
+  - cd docs && make html && cd ..
 deploy:
   provider: pypi
   user: mcquin

--- a/setup.py
+++ b/setup.py
@@ -1,71 +1,34 @@
-from __future__ import absolute_import, print_function
+import setuptools
 
-import os.path
-import re
-import subprocess
-from setuptools import setup, find_packages
-
-def get_version():
-    """Get version from git or file system.
-
-    If this is a git repository, try to get the version number by
-    running ``git describe``, then store it in
-    bioformats/_version.py. Otherwise, try to load the version number
-    from that file. If both methods fail, quietly return None.
-
-    """
-    git_version = None
-    if os.path.exists(os.path.join(os.path.dirname(__file__), '.git')):
-        import subprocess
-        try:
-            git_version = subprocess.check_output(['git', 'describe']).strip()
-        except:
-            pass
-
-    version_file = os.path.join(os.path.dirname(__file__), 'bioformats',
-                                '_version.py')
-    if os.path.exists(version_file):
-        with open(version_file) as f:
-            cached_version_line = f.read().strip()
-        try:
-            # From http://stackoverflow.com/a/3619714/17498
-            cached_version = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                                       cached_version_line, re.M).group(1)
-        except:
-            raise RuntimeError("Unable to find version in %s" % version_file)
-    else:
-        cached_version = None
-
-    if git_version and git_version != cached_version:
-        with open(version_file, 'w') as f:
-            print('__version__ = "%s"' % git_version, file=f)
-
-    return git_version or cached_version
-
-setup(
-    name="python-bioformats",
-    version=get_version().decode("utf-8"),
+setuptools.setup(
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Java",
+        "Topic :: Scientific/Engineering :: Bio-Informatics",
+        "Topic :: Multimedia :: Graphics :: Graphics Conversion"
+    ],
     description="Read and write life sciences file formats",
-    long_description='''Python-bioformats is a Python wrapper for Bio-Formats, a standalone
-    Java library for reading and writing life sciences image file
-    formats. Bio-Formats is capable of parsing both pixels and
-    metadata for a large number of formats, as well as writing to
-    several formats. Python-bioformats uses the python-javabridge to
-    start a Java virtual machine from Python and interact with
-    it. Python-bioformats was developed for and is used by the cell
-    image analysis software CellProfiler (cellprofiler.org).''',
+    install_requires=[
+        "javabridge>=1.0"
+    ],
+    license="GPL License",
+    long_description="""Python-bioformats is a Python wrapper for Bio-Formats, a standalone Java library for reading
+    and writing life sciences image file formats. Bio-Formats is capable of parsing both pixels and metadata for a
+    large number of formats, as well as writing to several formats. Python-bioformats uses the python-javabridge to
+    start a Java virtual machine from Python and interact with it. Python-bioformats was developed for and is used by
+    the cell image analysis software CellProfiler (cellprofiler.org).""",
+    name="python-bioformats",
+    package_data={
+        "bioformats": [
+            "jars/*.jar"
+        ]
+    },
+    packages=[
+        "bioformats"
+    ],
     url="http://github.com/CellProfiler/python-bioformats/",
-    packages=['bioformats'],
-    classifiers=['Development Status :: 5 - Production/Stable',
-                 'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
-                 'Programming Language :: Python :: 2',
-                 'Programming Language :: Python :: 3',
-                 'Programming Language :: Java',
-                 'Topic :: Scientific/Engineering :: Bio-Informatics',
-                 'Topic :: Multimedia :: Graphics :: Graphics Conversion'
-             ],
-    license='GPL License',
-    package_data={'bioformats': ['jars/*.jar']},
-    install_requires=['javabridge>=1.0']
+    version="1.0.9"
 )
-

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,47 @@
+from __future__ import absolute_import, print_function
+
+import sys
+import os.path
+import re
+import subprocess
 import setuptools
+
+def get_version():
+    """Get version from git or file system.
+
+    If this is a git repository, try to get the version number by
+    running ``git describe``, then store it in
+    bioformats/_version.py. Otherwise, try to load the version number
+    from that file. If both methods fail, quietly return None.
+
+    """
+    git_version = None
+    if os.path.exists(os.path.join(os.path.dirname(__file__), '.git')):
+        import subprocess
+        try:
+            git_version = subprocess.check_output(['git', 'describe']).strip()
+        except:
+            pass
+
+    version_file = os.path.join(os.path.dirname(__file__), 'bioformats',
+                                '_version.py')
+    if os.path.exists(version_file):
+        with open(version_file) as f:
+            cached_version_line = f.read().strip()
+        try:
+            # From http://stackoverflow.com/a/3619714/17498
+            cached_version = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                                       cached_version_line, re.M).group(1)
+        except:
+            raise RuntimeError("Unable to find version in %s" % version_file)
+    else:
+        cached_version = None
+
+    if git_version and git_version != cached_version:
+        with open(version_file, 'w') as f:
+            print('__version__ = "%s"' % git_version, file=f)
+
+    return git_version or cached_version
 
 setuptools.setup(
     author="Lee Kamentsky",
@@ -32,5 +75,5 @@ setuptools.setup(
         "bioformats"
     ],
     url="http://github.com/CellProfiler/python-bioformats/",
-    version="1.0.9"
+    version= str(get_version(),"utf-8") if sys.version_info.major == 3 else get_version().decode("utf-8"),
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 import setuptools
 
 setuptools.setup(
+    author="Lee Kamentsky",
+    author_email="leek@broadinstitute.org",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",


### PR DESCRIPTION
Python-bioformats now installs in python3.5 and python2.7 (see #56). 

A more permanent solution might involve doing str/bytes conversion in `get_version()`