### PR TITLE
Pure Python implementation of OmeroReader

### DIFF
--- a/bioformats/formatreader.py
+++ b/bioformats/formatreader.py
@@ -50,8 +50,13 @@ import bioformats
 from . import metadatatools as metadatatools
 import javabridge as javabridge
 
-from omero_reader import OmeroReader
-from omero_reader.utils import omero_on_the_path, omero_reader_enabled
+OMERO_READER_IMPORTED = False
+try:
+    from omero_reader import OmeroReader, OMERO_IMPORTED
+    from omero_reader.utils import omero_reader_enabled
+    OMERO_READER_IMPORTED = True
+except ImportError:
+    pass
 
 K_OMERO_SERVER = "omero_server"
 K_OMERO_PORT = "omero_port"
@@ -930,7 +935,8 @@ def get_image_reader(key, path=None, url=None):
         # is True OMERO python reader can be used to directly request
         # the image pixels from the server.
         # Following this route gives almost 10x speed up.
-        if omero_on_the_path() and omero_reader_enabled() and \
+        if OMERO_READER_IMPORTED and OMERO_IMPORTED and \
+                omero_reader_enabled() and \
                 url is not None and url.lower().startswith("omero:"):
             logger.debug("Initializing Python reader.")
             rdr = OmeroReader(__omero_server, __omero_session_id, url=url)

--- a/bioformats/formatreader.py
+++ b/bioformats/formatreader.py
@@ -50,6 +50,9 @@ import bioformats
 from . import metadatatools as metadatatools
 import javabridge as javabridge
 
+from omero_reader import OmeroReader
+from omero_reader.utils import omero_on_the_path, omero_reader_enabled
+
 K_OMERO_SERVER = "omero_server"
 K_OMERO_PORT = "omero_port"
 K_OMERO_USER = "omero_user"
@@ -913,6 +916,7 @@ def get_image_reader(key, path=None, url=None):
     key - use this key to keep only a single cache member associated with
           that key open at a time.
     '''
+    logger.debug("Getting image reader for: %s, %s, %s" % (key, path, url))
     if key in __image_reader_key_cache:
         old_path, old_url = __image_reader_key_cache[key]
         old_count, rdr = __image_reader_cache[old_path, old_url]
@@ -922,7 +926,17 @@ def get_image_reader(key, path=None, url=None):
     if (path, url) in __image_reader_cache:
         old_count, rdr = __image_reader_cache[path, url]
     else:
-        rdr = ImageReader(path=path, url=url)
+        # If OMERO.py is found on the PYTHONPATH and OMERO_READER_ENABLED
+        # is True OMERO python reader can be used to directly request
+        # the image pixels from the server.
+        # Following this route gives almost 10x speed up.
+        if omero_on_the_path() and omero_reader_enabled() and \
+                url is not None and url.lower().startswith("omero:"):
+            logger.debug("Initializing Python reader.")
+            rdr = OmeroReader(__omero_server, __omero_session_id, url=url)
+        else:
+            logger.debug("Falling back to Java reader.")
+            rdr = ImageReader(path=path, url=url)
         old_count = 0
     __image_reader_cache[path, url] = (old_count+1, rdr)
     __image_reader_key_cache[key] = (path, url)
@@ -945,6 +959,7 @@ def release_image_reader(key):
 def clear_image_reader_cache():
     '''Get rid of any open image readers'''
     for use_count, rdr in __image_reader_cache.values():
+        logger.debug("Closing reader %s" % rdr)
         rdr.close()
     __image_reader_cache.clear()
     __image_reader_key_cache.clear()


### PR DESCRIPTION
This PR adds support for a pure Python implementation of `OmeroReader` reader, which depends on OMERO.py, with the goal of making it an alternative implementation and preserving existing functionality. `omero-reader` is implemented in a separate repository (https://github.com/glencoesoftware/omero-reader) and is maintained by Glencoe Software, Inc. 

   `omero-reader` is designed to work in headless mode and is especially useful in cluster environments where fine control of resources is required. At the moment `omero-reader` can be used only in conjunction with LoadData module (standard input modules were not tested). The base implementation could be further extended to add support for Standard Input modules if such a use case is important.

  To use `omero-reader` with `python-bioformats` an environmental variable `OMERO_READER_ENABLED` has to be set to `1`. This allows to switch easily between existing functionality (Java reader) and the new one (Python reader) introduced in this PR regardless of the contents of your `PYTHONPATH`.

  In comparison to the existing reader `omero-reader` allows for the faster loading of planes (5x speed up in our testing) and frees the resources otherwise used by the JVM.