### PR TITLE
Encode both 'str' and 'unicode'

### DIFF
--- a/bioformats/omexml.py
+++ b/bioformats/omexml.py
@@ -315,7 +315,7 @@ class OMEXML(object):
     def __init__(self, xml=None):
         if xml is None:
             xml = default_xml
-        if isinstance(xml, str):
+        if isinstance(xml, basestring):
             xml = xml.encode("utf-8")
         self.dom = ElementTree.ElementTree(ElementTree.fromstring(xml))
 


### PR DESCRIPTION
This avoids unicode errors when parsing metadata with Python 2.7. See also issue #55 and this stackoverflow question:
 http://stackoverflow.com/questions/43598709/bioformats-python-error-ascii-codec-cant-encode-character-u-xb5-when-using/43630921#43630921