### PR TITLE
Update to class ImageReader docstring

### DIFF
--- a/bioformats/formatreader.py
+++ b/bioformats/formatreader.py
@@ -547,7 +547,7 @@ class ImageReader(object):
 
     This class is meant to be harnessed to a scope like this:
 
-    >>> with GetImageReader(path) as reader:
+    >>> with ImageReader(path) as reader:
     >>>     ....
 
     It uses `__enter__` and `__exit__` to manage the random access stream


### PR DESCRIPTION
The docstring for class ImageReader should use the correct class name in the example use case:
    This class is meant to be harnessed to a scope like this:
    >>> with ImageReader(path) as reader:
    >>>     ....