### PR TITLE
Add methods to access units for physical pixel sizes

### DIFF
--- a/bioformats/omexml.py
+++ b/bioformats/omexml.py
@@ -608,15 +608,36 @@ class OMEXML(object):
             '''
             return self.node.get("Type")
 
+        def get_PhysicalSizeXUnit(self):
+            '''The unit of length of a pixel in X direction.'''
+            return self.node.get("PhysicalSizeXUnit")
+        def set_PhysicalSizeXUnit(self, value):
+            self.node.set("PhysicalSizeXUnit", str(value))
+        PhysicalSizeXUnit = property(get_PhysicalSizeXUnit, set_PhysicalSizeXUnit)
+
+        def get_PhysicalSizeYUnit(self):
+            '''The unit of length of a pixel in Y direction.'''
+            return self.node.get("PhysicalSizeYUnit")
+        def set_PhysicalSizeYUnit(self, value):
+            self.node.set("PhysicalSizeYUnit", str(value))
+        PhysicalSizeYUnit = property(get_PhysicalSizeYUnit, set_PhysicalSizeYUnit)
+
+        def get_PhysicalSizeZUnit(self):
+            '''The unit of length of a voxel in Z direction.'''
+            return self.node.get("PhysicalSizeZUnit")
+        def set_PhysicalSizeZUnit(self, value):
+            self.node.set("PhysicalSizeZUnit", str(value))
+        PhysicalSizeZUnit = property(get_PhysicalSizeZUnit, set_PhysicalSizeZUnit)
+
         def get_PhysicalSizeX(self):
-            '''The length of a single pixel in microns in X direction'''
+            '''The length of a single pixel in X direction.'''
             return get_float_attr(self.node, "PhysicalSizeX")
         def set_PhysicalSizeX(self, value):
             self.node.set("PhysicalSizeX", str(value))
         PhysicalSizeX = property(get_PhysicalSizeX, set_PhysicalSizeX)
 
         def get_PhysicalSizeY(self):
-            '''The length of a single pixel in microns in Y direction'''
+            '''The length of a single pixel in Y direction.'''
             return get_float_attr(self.node, "PhysicalSizeY")
         def set_PhysicalSizeY(self, value):
             self.node.set("PhysicalSizeY", str(value))


### PR DESCRIPTION
This adds the corresponding "Unit" methods for all implemented "PhysicalSize"
properties of the `OMEXML.Image` class as requested in issue #101.

Please note that other unit attributes are still missing, important candidates
are e.g. `Plane.DeltaTUnit` and `Plane.ExposureTimeUnit`.