### PR TITLE
Update bioformats JAR to v5.9.0

### DIFF
--- a/bioformats/__init__.py
+++ b/bioformats/__init__.py
@@ -24,7 +24,7 @@ from . import formatwriter as _formatwriter
 
 _jars_dir = os.path.join(os.path.dirname(__file__), 'jars')
 
-JAR_VERSION = '5.7.1'
+JAR_VERSION = '5.9.0'
 
 JARS = javabridge.JARS + [os.path.realpath(os.path.join(_jars_dir, name + '.jar'))
                           for name in ['loci_tools']]


### PR DESCRIPTION
`pytest`s pass in a py3.6.5 pipenv. Please let me know if there's anything else to do for a bioformats version bump