### PR TITLE
Typo: J.kill_vm() --> javabridge.kill_vm()

### DIFF
--- a/bioformats/__init__.py
+++ b/bioformats/__init__.py
@@ -95,4 +95,4 @@ if __name__ == "__main__":
     import wx.py.PyCrust
 
     wx.py.PyCrust.main()
-    J.kill_vm()
+    javabridge.kill_vm()


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/CellProfiler/python-bioformats on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./bioformats/__init__.py:98:5: F821 undefined name 'J'
    J.kill_vm()
    ^
./bioformats/formatreader.py:751:59: F821 undefined name 'path'
                    "The file, \"%s\", does not exist." % path,
                                                          ^
./bioformats/formatreader.py:752:21: F821 undefined name 'path'
                    path)
                    ^
./bioformats/omexml.py:1164:39: F821 undefined name 'NS_SPW'
            make_text_node(self.node, NS_SPW, "Description", test)
                                      ^
./bioformats/omexml.py:1164:62: F821 undefined name 'test'
            make_text_node(self.node, NS_SPW, "Description", test)
                                                             ^
5     F821 undefined name 'J'
5
```