### PR TITLE
Added rectangle ROIs and TiffData to omexml.py

### DIFF
--- a/bioformats/omexml.py
+++ b/bioformats/omexml.py
@@ -1624,7 +1624,7 @@ class OMEXML(object):
             self.node = node
             self.ns = get_namespaces(self.node)
 
-        def rectangle(self, index=0):
+        def Rectangle(self):
             '''The OME/ROI/Union element. Currently only rectangle ROIs are available.'''
             return OMEXML.Rectangle(self.node.find(qn(self.ns['ome'], "Rectangle")))
 

--- a/bioformats/omexml.py
+++ b/bioformats/omexml.py
@@ -1,8 +1,3 @@
-
-# This file is a modified version of the python-bioformats omexml.py file.
-# New and modified sections have been clearly marked below.
-# Tom Fish 2019
-
 # Python-bioformats is distributed under the GNU General Public
 # License, but this file is licensed under the more permissive BSD
 # license.  See the accompanying file LICENSE for details.
@@ -543,7 +538,7 @@ class OMEXML(object):
         SamplesPerPixel = property(get_SamplesPerPixel, set_SamplesPerPixel)
 
     #---------------------
-    # The following section was taken from the Allen Institute for Cell Science version of this file
+    # The following section is from the Allen Institute for Cell Science version of this file
     # which can be found at https://github.com/AllenCellModeling/aicsimageio/blob/master/aicsimageio/vendor/omexml.py
     class TiffData(object):
         """The OME/Image/Pixels/TiffData element
@@ -651,23 +646,13 @@ class OMEXML(object):
 
         DeltaT = property(get_DeltaT, set_DeltaT)
 
-        #-------------
-        # Added 3/9/2019 by Tom Fish
-        def set_ExposureTime(self, value):
-            self.node.set("ExposureTime", str(value))
-
         def get_ExposureTime(self, value):
             self.node.get("ExposureTime")
 
-        #-------------
+        def set_ExposureTime(self, value):
+            self.node.set("ExposureTime", str(value))
 
-        @property
-        def ExposureTime(self):
-            '''Units are seconds. Duration of acquisition????'''
-            exposure_time = self.node.get("ExposureTime")
-            if exposure_time is not None:
-                return float(exposure_time)
-            return None
+        ExposureTime = property(get_ExposureTime, set_ExposureTime)
 
         def get_PositionX(self):
             '''X position of stage'''
@@ -699,8 +684,6 @@ class OMEXML(object):
 
         PositionZ = property(get_PositionZ, set_PositionZ)
 
-        #-------------
-        # Added 3/9/2019 by Tom Fish
         def get_PositionXUnit(self):
             self.node.get("PositionXUnit")
 
@@ -725,7 +708,6 @@ class OMEXML(object):
 
         PositionZUnit = property(get_PositionZUnit, set_PositionZUnit)
 
-        #-------------
     class Pixels(object):
         '''The OME/Image/Pixels element
 
@@ -942,8 +924,9 @@ class OMEXML(object):
             plane = self.node.findall(qn(self.ns['ome'], "Plane"))[index]
             return OMEXML.Plane(plane)
 
-        #-------------
-        # Added 3/9/2019 by Tom Fish
+        def get_tiffdata_count(self):
+            return len(self.node.findall(qn(self.ns['ome'], "TiffData")))
+
         def set_tiffdata_count(self, value):
             assert value >= 0
             tiffdatas = self.node.findall(qn(self.ns['ome'], "TiffData"))
@@ -956,7 +939,6 @@ class OMEXML(object):
         def TiffData(self, index=0):
             data = self.node.findall(qn(self.ns['ome'], "TiffData"))[index]
             return OMEXML.TiffData(data)
-        #-------------
 
     class Instrument(object):
         '''Representation of the OME/Instrument element'''
@@ -1631,8 +1613,6 @@ class OMEXML(object):
 
         ImageRef = property(get_ImageRef, set_ImageRef)
 
-    #-------------
-    # Added 9/9/2019 by Tom Fish
     class ROIRef(object):
 
         def __init__(self, node):
@@ -1645,7 +1625,7 @@ class OMEXML(object):
         def set_ID(self, value):
             '''
             ID will automatically be in the format "ROI:value"
-            and must match the ROI ID (which uses the same
+            and must match the ROI ID (that uses the same
             formatting)
             '''
             self.node.set("ID", "ROI:" + str(value))
@@ -1677,7 +1657,6 @@ class OMEXML(object):
             new_Rectangle.set_TheZ(0)
             new_Rectangle.set_TheC(0)
             new_Rectangle.set_TheT(0)
-
             new_Rectangle.set_StrokeColor(-16776961)  # Default = Red
             new_Rectangle.set_StrokeWidth(20)
             new_Rectangle.set_Text(str(iteration))
@@ -1700,7 +1679,7 @@ class OMEXML(object):
         def set_ID(self, value):
             '''
             ID will automatically be in the format "ROI:value"
-            and must match the ROIRef ID (which uses the same
+            and must match the ROIRef ID (that uses the same
             formatting)
             '''
             self.node.set("ID", "ROI:" + str(value))
@@ -1731,7 +1710,7 @@ class OMEXML(object):
             self.ns = get_namespaces(self.node)
 
         def Rectangle(self, index=0):
-            '''The OME/ROI/Union element. Currenly only rectangle ROIs are available.'''
+            '''The OME/ROI/Union element. Currently only rectangle ROIs are available.'''
             return OMEXML.Rectangle(self.node.find(qn(self.ns['ome'], "Rectangle")))
 
     class Rectangle(object):
@@ -1760,6 +1739,12 @@ class OMEXML(object):
             return self.node.get("StrokeWidth")
 
         def set_StrokeWidth(self, value):
+            '''
+            Colour is set using RGBA to integer conversion calculated using function from:
+            https://docs.openmicroscopy.org/omero/5.5.1/developers/Python.html
+            
+            RGB colours: Red=-16776961, Green=16711935, Blue=65535
+            '''
             self.node.set("StrokeWidth", str(value))
 
         StrokeWidth = property(get_StrokeWidth, set_StrokeWidth)
@@ -1830,4 +1815,3 @@ class OMEXML(object):
             self.node.set("TheT", str(value))
 
         TheT = property(get_TheT, set_TheT)
-    #-------------

--- a/bioformats/omexml.py
+++ b/bioformats/omexml.py
@@ -618,7 +618,10 @@ class OMEXML(object):
         DeltaT = property(get_DeltaT, set_DeltaT)
 
         def get_ExposureTime(self, value):
-            return self.node.get("ExposureTime")
+            exposure_time = self.node.get("ExposureTime")
+            if exposure_time is not None:
+                return float(exposure_time)
+            return None
 
         def set_ExposureTime(self, value):
             '''Units are seconds. Duration of acquisition????'''
@@ -835,7 +838,8 @@ class OMEXML(object):
             '''Get the indexed channel from the Pixels element'''
             channel = self.node.findall(qn(self.ns['ome'], "Channel"))[index]
             return OMEXML.Channel(channel)
-
+        channel = Channel
+        
         def get_plane_count(self):
             '''The number of planes in the image
 
@@ -869,7 +873,8 @@ class OMEXML(object):
             '''Get the indexed plane from the Pixels element'''
             plane = self.node.findall(qn(self.ns['ome'], "Plane"))[index]
             return OMEXML.Plane(plane)
-
+        plane = Plane
+        
         def get_tiffdata_count(self):
             return len(self.node.findall(qn(self.ns['ome'], "TiffData")))
 
@@ -884,7 +889,7 @@ class OMEXML(object):
 
         tiffdata_count = property(get_tiffdata_count, set_tiffdata_count)
 
-        def TiffData(self, index=0):
+        def tiffdata(self, index=0):
             data = self.node.findall(qn(self.ns['ome'], "TiffData"))[index]
             return OMEXML.TiffData(data)
 
@@ -1425,6 +1430,8 @@ class OMEXML(object):
 
         def set_Color(self, value):
             self.node.set("Color", str(value))
+            
+        Color = property(get_Color, set_Color)
 
     class WellSampleDucktype(list):
         '''The WellSample elements in a well
@@ -1574,6 +1581,10 @@ class OMEXML(object):
             new_Rectangle.set_y(0)
 
     roi_count = property(get_roi_count, set_roi_count)
+    
+    def roi(self, index=0):
+        '''Return an ROI node by index'''
+        return self.ROI(self.root_node.findall(qn(self.ns['ome'], "ROI"))[index])
 
     class ROI(object):
 
@@ -1607,17 +1618,13 @@ class OMEXML(object):
             '''The OME/ROI/Union element.'''
             return OMEXML.Union(self.node.find(qn(self.ns['ome'], "Union")))
 
-    def roi(self, index=0):
-        '''Return an ROI node by index'''
-        return self.ROI(self.root_node.findall(qn(self.ns['ome'], "ROI"))[index])
-
     class Union(object):
 
         def __init__(self, node):
             self.node = node
             self.ns = get_namespaces(self.node)
 
-        def Rectangle(self, index=0):
+        def rectangle(self, index=0):
             '''The OME/ROI/Union element. Currently only rectangle ROIs are available.'''
             return OMEXML.Rectangle(self.node.find(qn(self.ns['ome'], "Rectangle")))
 

--- a/bioformats/omexml.py
+++ b/bioformats/omexml.py
@@ -29,11 +29,9 @@ logger = logging.getLogger(__file__)
 import re
 import uuid
 
-
 def xsd_now():
     '''Return the current time in xsd:dateTime format'''
     return datetime.datetime.now().isoformat()
-
 
 DEFAULT_NOW = xsd_now()
 #
@@ -129,7 +127,7 @@ MPI_MONOCHROME = "Monochrome"
 MPI_CMYK = "CMYK"
 
 '''IFD # 263'''
-OM_THRESHHOLDING = "Threshholding"  # (sic)
+OM_THRESHHOLDING = "Threshholding" # (sic)
 '''IFD # 264 (but can be 265 if the orientation = 8)'''
 OM_CELL_WIDTH = "CellWidth"
 '''IFD # 265'''
@@ -212,7 +210,6 @@ OM_COPYRIGHT = "Copyright"
 NC_LETTER = "letter"
 NC_NUMBER = "number"
 
-
 def page_name_original_metadata(index):
     '''Get the key name for the page name metadata data for the indexed tiff page
 
@@ -222,16 +219,13 @@ def page_name_original_metadata(index):
     '''
     return "PageName #%d" % index
 
-
 def get_text(node):
     '''Get the contents of text nodes in a parent node'''
     return node.text
 
-
 def set_text(node, text):
     '''Set the text of a parent'''
     node.text = text
-
 
 def qn(namespace, tag_name):
     '''Return the qualified name for a given namespace and tag name
@@ -240,12 +234,10 @@ def qn(namespace, tag_name):
     '''
     return "{%s}%s" % (namespace, tag_name)
 
-
 def split_qn(qn):
     '''Split a qualified tag name or return None if namespace not present'''
     m = re.match('\{(.*)\}(.*)', qn)
     return m.group(1), m.group(2) if m else None
-
 
 def get_namespaces(node):
     '''Get top-level XML namespaces from a node.'''
@@ -258,18 +250,15 @@ def get_namespaces(node):
             ns_lib[ns_key] = ns
     return ns_lib
 
-
 def get_float_attr(node, attribute):
     '''Cast an element attribute to a float or return None if not present'''
     attr = node.get(attribute)
     return None if attr is None else float(attr)
 
-
 def get_int_attr(node, attribute):
     '''Cast an element attribute to an int or return None if not present'''
     attr = node.get(attribute)
     return None if attr is None else int(attr)
-
 
 def make_text_node(parent, namespace, tag_name, text):
     '''Either make a new node and add the given text or replace the text
@@ -284,7 +273,6 @@ def make_text_node(parent, namespace, tag_name, text):
     if node is None:
         node = ElementTree.SubElement(parent, qname)
     set_text(node, text)
-
 
 class OMEXML(object):
     '''Reads and writes OME-XML with methods to get and set it.
@@ -329,7 +317,6 @@ class OMEXML(object):
     See the `OME-XML schema documentation <http://git.openmicroscopy.org/src/develop/components/specification/Documentation/Generated/OME-2011-06/ome.html>`_.
 
     '''
-
     def __init__(self, xml=None):
         if xml is None:
             xml = default_xml
@@ -424,7 +411,6 @@ class OMEXML(object):
 
     class Image(object):
         '''Representation of the OME/Image element'''
-
         def __init__(self, node):
             '''Initialize with the DOM Image node'''
             self.node = node
@@ -440,10 +426,8 @@ class OMEXML(object):
 
         def get_Name(self):
             return self.node.get("Name")
-
         def set_Name(self, value):
             self.node.set("Name", value)
-
         Name = property(get_Name, set_Name)
 
         def get_AcquisitionDate(self):
@@ -459,8 +443,8 @@ class OMEXML(object):
                 acquired_date = ElementTree.SubElement(
                     self.node, qn(self.ns["ome"], "AcquisitionDate"))
             set_text(acquired_date, date)
-
         AcquisitionDate = property(get_AcquisitionDate, set_AcquisitionDate)
+
 
         @property
         def Pixels(self):
@@ -477,15 +461,12 @@ class OMEXML(object):
             '''
             return OMEXML.Pixels(self.node.find(qn(self.ns['ome'], "Pixels")))
 
-        #-------------
-        # Added 9/9/2019 by Tom Fish
         def roiref(self, index=0):
-            # The OME/Image/ROIRef element.
+            '''The OME/Image/ROIRef element'''
             return OMEXML.ROIRef(self.node.findall(qn(self.ns['ome'], "ROIRef"))[index])
 
         def get_roiref_count(self):
             return len(self.node.findall(qn(self.ns['ome'], "ROIRef")))
-
         def set_roiref_count(self, value):
             '''Add or remove roirefs as needed'''
             assert value > 0
@@ -500,33 +481,26 @@ class OMEXML(object):
 
         roiref_count = property(get_roiref_count, set_roiref_count)
 
-    #-------------
-
     def image(self, index=0):
         '''Return an image node by index'''
         return self.Image(self.root_node.findall(qn(self.ns['ome'], "Image"))[index])
 
     class Channel(object):
         '''The OME/Image/Pixels/Channel element'''
-
         def __init__(self, node):
             self.node = node
             self.ns = get_namespaces(node)
 
         def get_ID(self):
             return self.node.get("ID")
-
         def set_ID(self, value):
             self.node.set("ID", value)
-
         ID = property(get_ID, set_ID)
 
         def get_Name(self):
             return self.node.get("Name")
-
         def set_Name(self, value):
             self.node.set("Name", value)
-
         Name = property(get_Name, set_Name)
 
         def get_SamplesPerPixel(self):
@@ -534,7 +508,6 @@ class OMEXML(object):
 
         def set_SamplesPerPixel(self, value):
             self.node.set("SamplesPerPixel", str(value))
-
         SamplesPerPixel = property(get_SamplesPerPixel, set_SamplesPerPixel)
 
     #---------------------
@@ -596,7 +569,6 @@ class OMEXML(object):
             self.node.set("PlaneCount", str(value))
 
         plane_count = property(get_plane_count, set_plane_count)
-    #---------------------
 
     class Plane(object):
         '''The OME/Image/Pixels/Plane element
@@ -605,7 +577,6 @@ class OMEXML(object):
         has the Z, C and T indices of the plane and optionally has the
         X, Y, Z, exposure time and a relative time delta.
         '''
-
         def __init__(self, node):
             self.node = node
             self.ns = get_namespaces(self.node)
@@ -650,6 +621,7 @@ class OMEXML(object):
             return self.node.get("ExposureTime")
 
         def set_ExposureTime(self, value):
+            '''Units are seconds. Duration of acquisition????'''
             self.node.set("ExposureTime", str(value))
 
         ExposureTime = property(get_ExposureTime, set_ExposureTime)
@@ -716,17 +688,14 @@ class OMEXML(object):
         pixel data. It has the X, Y, Z, C, and T extents of the image
         and it specifies the channel interleaving and channel depth.
         '''
-
         def __init__(self, node):
             self.node = node
             self.ns = get_namespaces(self.node)
 
         def get_ID(self):
             return self.node.get("ID")
-
         def set_ID(self, value):
             self.node.set("ID", value)
-
         ID = property(get_ID, set_ID)
 
         def get_DimensionOrder(self):
@@ -737,10 +706,8 @@ class OMEXML(object):
             DO_XYZCT) to compare and set this.
             '''
             return self.node.get("DimensionOrder")
-
         def set_DimensionOrder(self, value):
             self.node.set("DimensionOrder", value)
-
         DimensionOrder = property(get_DimensionOrder, set_DimensionOrder)
 
         def get_PixelType(self):
@@ -755,78 +722,61 @@ class OMEXML(object):
         def get_PhysicalSizeXUnit(self):
             '''The unit of length of a pixel in X direction.'''
             return self.node.get("PhysicalSizeXUnit")
-
         def set_PhysicalSizeXUnit(self, value):
             self.node.set("PhysicalSizeXUnit", str(value))
-
         PhysicalSizeXUnit = property(get_PhysicalSizeXUnit, set_PhysicalSizeXUnit)
 
         def get_PhysicalSizeYUnit(self):
             '''The unit of length of a pixel in Y direction.'''
             return self.node.get("PhysicalSizeYUnit")
-
         def set_PhysicalSizeYUnit(self, value):
             self.node.set("PhysicalSizeYUnit", str(value))
-
         PhysicalSizeYUnit = property(get_PhysicalSizeYUnit, set_PhysicalSizeYUnit)
 
         def get_PhysicalSizeZUnit(self):
             '''The unit of length of a voxel in Z direction.'''
             return self.node.get("PhysicalSizeZUnit")
-
         def set_PhysicalSizeZUnit(self, value):
             self.node.set("PhysicalSizeZUnit", str(value))
-
         PhysicalSizeZUnit = property(get_PhysicalSizeZUnit, set_PhysicalSizeZUnit)
 
         def get_PhysicalSizeX(self):
             '''The length of a single pixel in X direction.'''
             return get_float_attr(self.node, "PhysicalSizeX")
-
         def set_PhysicalSizeX(self, value):
             self.node.set("PhysicalSizeX", str(value))
-
         PhysicalSizeX = property(get_PhysicalSizeX, set_PhysicalSizeX)
 
         def get_PhysicalSizeY(self):
             '''The length of a single pixel in Y direction.'''
             return get_float_attr(self.node, "PhysicalSizeY")
-
         def set_PhysicalSizeY(self, value):
             self.node.set("PhysicalSizeY", str(value))
-
         PhysicalSizeY = property(get_PhysicalSizeY, set_PhysicalSizeY)
 
         def get_PhysicalSizeZ(self):
             '''The size of a voxel in Z direction or None for 2D images.'''
             return get_float_attr(self.node, "PhysicalSizeZ")
-
         def set_PhysicalSizeZ(self, value):
             self.node.set("PhysicalSizeZ", str(value))
-
         PhysicalSizeZ = property(get_PhysicalSizeZ, set_PhysicalSizeZ)
 
         def set_PixelType(self, value):
             self.node.set("Type", value)
-
         PixelType = property(get_PixelType, set_PixelType)
 
         def get_SizeX(self):
             '''The dimensions of the image in the X direction in pixels'''
             return get_int_attr(self.node, "SizeX")
-
         def set_SizeX(self, value):
             self.node.set("SizeX", str(value))
-
         SizeX = property(get_SizeX, set_SizeX)
 
         def get_SizeY(self):
             '''The dimensions of the image in the Y direction in pixels'''
             return get_int_attr(self.node, "SizeY")
-
         def set_SizeY(self, value):
             self.node.set("SizeY", str(value))
-
         SizeY = property(get_SizeY, set_SizeY)
 
         def get_SizeZ(self):
@@ -835,7 +785,6 @@ class OMEXML(object):
 
         def set_SizeZ(self, value):
             self.node.set("SizeZ", str(value))
-
         SizeZ = property(get_SizeZ, set_SizeZ)
 
         def get_SizeT(self):
@@ -844,16 +793,13 @@ class OMEXML(object):
 
         def set_SizeT(self, value):
             self.node.set("SizeT", str(value))
-
         SizeT = property(get_SizeT, set_SizeT)
 
         def get_SizeC(self):
             '''The dimensions of the image in the C direction in pixels'''
             return get_int_attr(self.node, "SizeC")
-
         def set_SizeC(self, value):
             self.node.set("SizeC", str(value))
-
         SizeC = property(get_SizeC, set_SizeC)
 
         def get_channel_count(self):
@@ -890,7 +836,7 @@ class OMEXML(object):
             channel = self.node.findall(qn(self.ns['ome'], "Channel"))[index]
             return OMEXML.Channel(channel)
 
-        def get_PlaneCount(self):
+        def get_plane_count(self):
             '''The number of planes in the image
 
             An image with only one plane or an interleaved color plane will
@@ -944,7 +890,6 @@ class OMEXML(object):
 
     class Instrument(object):
         '''Representation of the OME/Instrument element'''
-
         def __init__(self, node):
             self.node = node
             self.ns = get_namespaces(self.node)
@@ -960,26 +905,25 @@ class OMEXML(object):
         @property
         def Detector(self):
             return OMEXML.Detector(self.node.find(qn(self.ns['ome'], "Detector")))
-
+        
         @property
         def Objective(self):
             return OMEXML.Objective(self.node.find(qn(self.ns['ome'], "Objective")))
 
+
     def instrument(self, index=0):
         return self.Instrument(self.root_node.findall(qn(self.ns['ome'], "Instrument"))[index])
 
-    class Objective(object):
 
+    class Objective(object):
         def __init__(self, node):
             self.node = node
             self.ns = get_namespaces(self.node)
 
         def get_ID(self):
             return self.node.get("ID")
-
         def set_ID(self, value):
             self.node.set("ID", value)
-
         ID = property(get_ID, set_ID)
 
         def get_LensNA(self):
@@ -987,37 +931,29 @@ class OMEXML(object):
 
         def set_LensNA(self, value):
             self.node.set("LensNA", value)
-
         LensNA = property(get_LensNA, set_LensNA)
 
         def get_NominalMagnification(self):
             return self.node.get("NominalMagnification")
-
         def set_NominalMagnification(self, value):
             self.node.set("NominalMagnification", value)
-
         NominalMagnification = property(get_NominalMagnification, set_NominalMagnification)
 
         def get_WorkingDistanceUnit(self):
             return get_int_attr(self.node, "WorkingDistanceUnit")
-
         def set_WorkingDistanceUnit(self, value):
             self.node.set("WorkingDistanceUnit", str(value))
-
         WorkingDistanceUnit = property(get_WorkingDistanceUnit, set_WorkingDistanceUnit)
-
+    
     class Detector(object):
-
         def __init__(self, node):
             self.node = node
             self.ns = get_namespaces(self.node)
 
         def get_ID(self):
             return self.node.get("ID")
-
         def set_ID(self, value):
             self.node.set("ID", value)
-
         ID = property(get_ID, set_ID)
 
         def get_Gain(self):
@@ -1025,24 +961,21 @@ class OMEXML(object):
 
         def set_Gain(self, value):
             self.node.set("Gain", value)
-
         Gain = property(get_Gain, set_Gain)
 
         def get_Model(self):
             return self.node.get("Model")
-
         def set_Model(self, value):
             self.node.set("Model", value)
-
         Model = property(get_Model, set_Model)
 
         def get_Type(self):
             return get_int_attr(self.node, "Type")
-
         def set_Type(self, value):
             self.node.set("Type", str(value))
-
         Type = property(get_Type, set_Type)
+
+
 
     class StructuredAnnotations(dict):
         '''The OME/StructuredAnnotations element
@@ -1180,7 +1113,7 @@ class OMEXML(object):
             returns a dictionary of key to value
             '''
             d = {}
-            for annotation_id, (k, v) in self.iter_original_metadata():
+            for annotation_id, (k,v) in self.iter_original_metadata():
                 if annotation_id in ids:
                     d[k] = v
             return d
@@ -1195,7 +1128,6 @@ class OMEXML(object):
         Original metadata holds "vendor-specific" metadata including TIFF
         tag values.
         '''
-
         def __init__(self, sa):
             '''Initialized with the structured_annotations class instance'''
             self.sa = sa
@@ -1233,7 +1165,6 @@ class OMEXML(object):
 
     class PlatesDucktype(object):
         '''It looks like a list of plates'''
-
         def __init__(self, root):
             self.root = root
             self.ns = get_namespaces(self.root)
@@ -1251,7 +1182,7 @@ class OMEXML(object):
             for plate in self.root.iterfind(qn(self.ns['spw'], "Plate")):
                 yield OMEXML.Plate(plate)
 
-        def newPlate(self, name, plate_id=str(uuid.uuid4())):
+        def newPlate(self, name, plate_id = str(uuid.uuid4())):
             new_plate_node = ElementTree.SubElement(
                 self.root, qn(self.ns['spw'], "Plate"))
             new_plate = OMEXML.Plate(new_plate_node)
@@ -1265,7 +1196,6 @@ class OMEXML(object):
         This represents the plate element of the SPW schema:
         http://www.openmicroscopy.org/Schemas/SPW/2007-06/
         '''
-
         def __init__(self, node):
             self.node = node
             self.ns = get_namespaces(self.node)
@@ -1309,7 +1239,6 @@ class OMEXML(object):
         def set_ColumnNamingConvention(self, value):
             assert value in (NC_LETTER, NC_NUMBER)
             self.node.set("ColumnNamingConvention", value)
-
         ColumnNamingConvention = property(get_ColumnNamingConvention,
                                           set_ColumnNamingConvention)
 
@@ -1320,7 +1249,6 @@ class OMEXML(object):
         def set_RowNamingConvention(self, value):
             assert value in (NC_LETTER, NC_NUMBER)
             self.node.set("RowNamingConvention", value)
-
         RowNamingConvention = property(get_RowNamingConvention,
                                        set_RowNamingConvention)
 
@@ -1329,7 +1257,6 @@ class OMEXML(object):
 
         def set_WellOriginX(self, value):
             self.node.set("WellOriginX", str(value))
-
         WellOriginX = property(get_WellOriginX, set_WellOriginX)
 
         def get_WellOriginY(self):
@@ -1337,7 +1264,6 @@ class OMEXML(object):
 
         def set_WellOriginY(self, value):
             self.node.set("WellOriginY", str(value))
-
         WellOriginY = property(get_WellOriginY, set_WellOriginY)
 
         def get_Rows(self):
@@ -1364,19 +1290,17 @@ class OMEXML(object):
 
         def set_Description(self, text):
             make_text_node(self.node, self.ns['spw'], "Description", text)
-
         Description = property(get_Description, set_Description)
 
         def get_Well(self):
             '''The well dictionary / list'''
             return OMEXML.WellsDucktype(self)
-
         Well = property(get_Well)
 
         def get_well_name(self, well):
             '''Get a well's name, using the row and column convention'''
             result = "".join([
-                "%02d" % (i + 1) if convention == NC_NUMBER
+                "%02d" % (i+1) if convention == NC_NUMBER
                 else "ABCDEFGHIJKLMNOP"[i]
                 for i, convention
                 in ((well.Row, self.RowNamingConvention or NC_LETTER),
@@ -1398,7 +1322,6 @@ class OMEXML(object):
         If the ducktype is unable to parse a well name, it assumes you're
         using an ID.
         '''
-
         def __init__(self, plate):
             self.plate_node = plate.node
             self.plate = plate
@@ -1440,7 +1363,7 @@ class OMEXML(object):
                 well.node = w
                 yield self.plate.get_well_name(well)
 
-        def new(self, row, column, well_id=str(uuid.uuid4())):
+        def new(self, row, column, well_id = str(uuid.uuid4())):
             '''Create a new well at the given row and column
 
             row - index of well's row
@@ -1456,37 +1379,29 @@ class OMEXML(object):
             return well
 
     class Well(object):
-
         def __init__(self, node):
             self.node = node
 
         def get_Column(self):
             return get_int_attr(self.node, "Column")
-
         def set_Column(self, value):
             self.node.set("Column", str(value))
-
         Column = property(get_Column, set_Column)
 
         def get_Row(self):
             return get_int_attr(self.node, "Row")
-
         def set_Row(self, value):
             self.node.set("Row", str(value))
-
         Row = property(get_Row, set_Row)
 
         def get_ID(self):
             return self.node.get("ID")
-
         def set_ID(self, value):
             self.node.set("ID", value)
-
         ID = property(get_ID, set_ID)
 
         def get_Sample(self):
             return OMEXML.WellSampleDucktype(self.node)
-
         Sample = property(get_Sample)
 
         def get_ExternalDescription(self):
@@ -1518,7 +1433,6 @@ class OMEXML(object):
         things like:
         wellsamples[0:2]
         '''
-
         def __init__(self, well_node):
             self.well_node = well_node
             self.ns = get_namespaces(self.well_node)
@@ -1539,7 +1453,7 @@ class OMEXML(object):
             for s in all_samples:
                 yield OMEXML.WellSample(s)
 
-        def new(self, wellsample_id=str(uuid.uuid4()), index=None):
+        def new(self, wellsample_id = str(uuid.uuid4()), index = None):
             '''Create a new well sample
             '''
             if index is None:
@@ -1552,25 +1466,20 @@ class OMEXML(object):
 
     class WellSample(object):
         '''The WellSample is a location within a well'''
-
         def __init__(self, node):
             self.node = node
             self.ns = get_namespaces(self.node)
 
         def get_ID(self):
             return self.node.get("ID")
-
         def set_ID(self, value):
             self.node.set("ID", value)
-
         ID = property(get_ID, set_ID)
 
         def get_PositionX(self):
             return get_float_attr(self.node, "PositionX")
-
         def set_PositionX(self, value):
             self.node.set("PositionX", str(value))
-
         PositionX = property(get_PositionX, set_PositionX)
 
         def get_PositionY(self):
@@ -1578,7 +1487,6 @@ class OMEXML(object):
 
         def set_PositionY(self, value):
             self.node.set("PositionY", str(value))
-
         PositionY = property(get_PositionY, set_PositionY)
 
         def get_Timepoint(self):
@@ -1588,7 +1496,6 @@ class OMEXML(object):
             if isinstance(value, datetime.datetime):
                 value = value.isoformat()
             self.node.set("Timepoint", value)
-
         Timepoint = property(get_Timepoint, set_Timepoint)
 
         def get_Index(self):
@@ -1612,7 +1519,6 @@ class OMEXML(object):
             if ref is None:
                 ref = ElementTree.SubElement(self.node, qn(self.ns['spw'], "ImageRef"))
             ref.set("ID", value)
-
         ImageRef = property(get_ImageRef, set_ImageRef)
 
     class ROIRef(object):

--- a/bioformats/omexml.py
+++ b/bioformats/omexml.py
@@ -1575,10 +1575,10 @@ class OMEXML(object):
             new_Rectangle.set_StrokeColor(-16776961)  # Default = Red
             new_Rectangle.set_StrokeWidth(20)
             new_Rectangle.set_Text(str(iteration))
-            new_Rectangle.set_width(512)
-            new_Rectangle.set_height(512)
-            new_Rectangle.set_x(0)
-            new_Rectangle.set_y(0)
+            new_Rectangle.set_Width(512)
+            new_Rectangle.set_Height(512)
+            new_Rectangle.set_X(0)
+            new_Rectangle.set_Y(0)
 
     roi_count = property(get_roi_count, set_roi_count)
     

--- a/bioformats/omexml.py
+++ b/bioformats/omexml.py
@@ -617,7 +617,7 @@ class OMEXML(object):
 
         DeltaT = property(get_DeltaT, set_DeltaT)
 
-        def get_ExposureTime(self, value):
+        def get_ExposureTime(self):
             exposure_time = self.node.get("ExposureTime")
             if exposure_time is not None:
                 return float(exposure_time)

--- a/bioformats/omexml.py
+++ b/bioformats/omexml.py
@@ -588,14 +588,14 @@ class OMEXML(object):
 
         IFD = property(get_IFD, set_IFD)
 
-        def get_PlaneCount(self):
+        def get_plane_count(self):
             '''How many planes in this TiffData. Should always be 1'''
             return get_int_attr(self.node, "PlaneCount")
 
-        def set_PlaneCount(self, value):
+        def set_plane_count(self, value):
             self.node.set("PlaneCount", str(value))
 
-        PlaneCount = property(get_PlaneCount, set_PlaneCount)
+        plane_count = property(get_plane_count, set_plane_count)
     #---------------------
 
     class Plane(object):
@@ -647,7 +647,7 @@ class OMEXML(object):
         DeltaT = property(get_DeltaT, set_DeltaT)
 
         def get_ExposureTime(self, value):
-            self.node.get("ExposureTime")
+            return self.node.get("ExposureTime")
 
         def set_ExposureTime(self, value):
             self.node.set("ExposureTime", str(value))
@@ -685,7 +685,7 @@ class OMEXML(object):
         PositionZ = property(get_PositionZ, set_PositionZ)
 
         def get_PositionXUnit(self):
-            self.node.get("PositionXUnit")
+            return self.node.get("PositionXUnit")
 
         def set_PositionXUnit(self, value):
             self.node.set("PositionXUnit", str(value))
@@ -693,7 +693,7 @@ class OMEXML(object):
         PositionXUnit = property(get_PositionXUnit, set_PositionXUnit)
 
         def get_PositionYUnit(self):
-            self.node.get("PositionYUnit")
+            return self.node.get("PositionYUnit")
 
         def set_PositionYUnit(self, value):
             self.node.set("PositionYUnit", str(value))
@@ -701,7 +701,7 @@ class OMEXML(object):
         PositionYUnit = property(get_PositionYUnit, set_PositionYUnit)
 
         def get_PositionZUnit(self):
-            self.node.get("PositionZUnit")
+            return self.node.get("PositionZUnit")
 
         def set_PositionZUnit(self, value):
             self.node.set("PositionZUnit", str(value))
@@ -890,7 +890,7 @@ class OMEXML(object):
             channel = self.node.findall(qn(self.ns['ome'], "Channel"))[index]
             return OMEXML.Channel(channel)
 
-        def get_plane_count(self):
+        def get_PlaneCount(self):
             '''The number of planes in the image
 
             An image with only one plane or an interleaved color plane will
@@ -935,6 +935,8 @@ class OMEXML(object):
             for _ in range(0, value):
                 new_tiffdata = OMEXML.TiffData(
                     ElementTree.SubElement(self.node, qn(self.ns['ome'], "TiffData")))
+
+        tiffdata_count = property(get_tiffdata_count, set_tiffdata_count)
 
         def TiffData(self, index=0):
             data = self.node.findall(qn(self.ns['ome'], "TiffData"))[index]
@@ -1686,13 +1688,13 @@ class OMEXML(object):
 
         ID = property(get_ID, set_ID)
 
-        def get_name(self):
+        def get_Name(self):
             return self.node.get("Name")
 
-        def set_name(self, value):
+        def set_Name(self, value):
             self.node.set("Name", str(value))
 
-        Name = property(get_name, set_name)
+        Name = property(get_Name, set_Name)
 
         @property
         def Union(self):
@@ -1757,37 +1759,37 @@ class OMEXML(object):
 
         Text = property(get_Text, set_Text)
 
-        def get_height(self):
+        def get_Height(self):
             return self.node.get("Height")
 
-        def set_height(self, value):
+        def set_Height(self, value):
             self.node.set("Height", str(value))
 
-        Height = property(get_height, set_height)
+        Height = property(get_Height, set_Height)
 
-        def get_width(self):
+        def get_Width(self):
             return self.node.get("Width")
 
-        def set_width(self, value):
+        def set_Width(self, value):
             self.node.set("Width", str(value))
 
-        Width = property(get_width, set_width)
+        Width = property(get_Width, set_Width)
 
-        def get_x(self):
+        def get_X(self):
             return self.node.get("X")
 
-        def set_x(self, value):
+        def set_X(self, value):
             self.node.set("X", str(value))
 
-        X = property(get_x, set_x)
+        X = property(get_X, set_X)
 
-        def get_y(self):
+        def get_Y(self):
             return self.node.get("Y")
 
-        def set_y(self, value):
+        def set_Y(self, value):
             self.node.set("Y", str(value))
 
-        Y = property(get_y, set_y)
+        Y = property(get_Y, set_Y)
 
         def get_TheZ(self):
             '''The Z index of the plane'''

--- a/bioformats/omexml.py
+++ b/bioformats/omexml.py
@@ -1,3 +1,8 @@
+
+# This file is a modified version of the python-bioformats omexml.py file.
+# New and modified sections have been clearly marked below.
+# Tom Fish 2019
+
 # Python-bioformats is distributed under the GNU General Public
 # License, but this file is licensed under the more permissive BSD
 # license.  See the accompanying file LICENSE for details.
@@ -29,9 +34,11 @@ logger = logging.getLogger(__file__)
 import re
 import uuid
 
+
 def xsd_now():
     '''Return the current time in xsd:dateTime format'''
     return datetime.datetime.now().isoformat()
+
 
 DEFAULT_NOW = xsd_now()
 #
@@ -43,6 +50,11 @@ NS_DEFAULT = "http://www.openmicroscopy.org/Schemas/{ns_key}/2013-06"
 NS_RE = r"http://www.openmicroscopy.org/Schemas/(?P<ns_key>.*)/[0-9/-]"
 
 default_xml = """<?xml version="1.0" encoding="UTF-8"?>
+<!-- Warning: this comment is an OME-XML metadata block, which contains
+crucial dimensional parameters and other important metadata. Please edit
+cautiously (if at all), and back up the original data before doing so.
+For more information, see the OME-TIFF documentation:
+https://docs.openmicroscopy.org/latest/ome-model/ome-tiff/ -->
 <OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06 http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
@@ -122,7 +134,7 @@ MPI_MONOCHROME = "Monochrome"
 MPI_CMYK = "CMYK"
 
 '''IFD # 263'''
-OM_THRESHHOLDING = "Threshholding" # (sic)
+OM_THRESHHOLDING = "Threshholding"  # (sic)
 '''IFD # 264 (but can be 265 if the orientation = 8)'''
 OM_CELL_WIDTH = "CellWidth"
 '''IFD # 265'''
@@ -205,6 +217,7 @@ OM_COPYRIGHT = "Copyright"
 NC_LETTER = "letter"
 NC_NUMBER = "number"
 
+
 def page_name_original_metadata(index):
     '''Get the key name for the page name metadata data for the indexed tiff page
 
@@ -214,13 +227,16 @@ def page_name_original_metadata(index):
     '''
     return "PageName #%d" % index
 
+
 def get_text(node):
     '''Get the contents of text nodes in a parent node'''
     return node.text
 
+
 def set_text(node, text):
     '''Set the text of a parent'''
     node.text = text
+
 
 def qn(namespace, tag_name):
     '''Return the qualified name for a given namespace and tag name
@@ -229,10 +245,12 @@ def qn(namespace, tag_name):
     '''
     return "{%s}%s" % (namespace, tag_name)
 
+
 def split_qn(qn):
     '''Split a qualified tag name or return None if namespace not present'''
     m = re.match('\{(.*)\}(.*)', qn)
     return m.group(1), m.group(2) if m else None
+
 
 def get_namespaces(node):
     '''Get top-level XML namespaces from a node.'''
@@ -245,15 +263,18 @@ def get_namespaces(node):
             ns_lib[ns_key] = ns
     return ns_lib
 
+
 def get_float_attr(node, attribute):
     '''Cast an element attribute to a float or return None if not present'''
     attr = node.get(attribute)
     return None if attr is None else float(attr)
 
+
 def get_int_attr(node, attribute):
     '''Cast an element attribute to an int or return None if not present'''
     attr = node.get(attribute)
     return None if attr is None else int(attr)
+
 
 def make_text_node(parent, namespace, tag_name, text):
     '''Either make a new node and add the given text or replace the text
@@ -268,6 +289,7 @@ def make_text_node(parent, namespace, tag_name, text):
     if node is None:
         node = ElementTree.SubElement(parent, qname)
     set_text(node, text)
+
 
 class OMEXML(object):
     '''Reads and writes OME-XML with methods to get and set it.
@@ -312,6 +334,7 @@ class OMEXML(object):
     See the `OME-XML schema documentation <http://git.openmicroscopy.org/src/develop/components/specification/Documentation/Generated/OME-2011-06/ome.html>`_.
 
     '''
+
     def __init__(self, xml=None):
         if xml is None:
             xml = default_xml
@@ -406,6 +429,7 @@ class OMEXML(object):
 
     class Image(object):
         '''Representation of the OME/Image element'''
+
         def __init__(self, node):
             '''Initialize with the DOM Image node'''
             self.node = node
@@ -421,8 +445,10 @@ class OMEXML(object):
 
         def get_Name(self):
             return self.node.get("Name")
+
         def set_Name(self, value):
             self.node.set("Name", value)
+
         Name = property(get_Name, set_Name)
 
         def get_AcquisitionDate(self):
@@ -438,8 +464,8 @@ class OMEXML(object):
                 acquired_date = ElementTree.SubElement(
                     self.node, qn(self.ns["ome"], "AcquisitionDate"))
             set_text(acquired_date, date)
-        AcquisitionDate = property(get_AcquisitionDate, set_AcquisitionDate)
 
+        AcquisitionDate = property(get_AcquisitionDate, set_AcquisitionDate)
 
         @property
         def Pixels(self):
@@ -456,26 +482,56 @@ class OMEXML(object):
             '''
             return OMEXML.Pixels(self.node.find(qn(self.ns['ome'], "Pixels")))
 
+        #-------------
+        # Added 9/9/2019 by Tom Fish
+        def roiref(self, index=0):
+            # The OME/Image/ROIRef element.
+            return OMEXML.ROIRef(self.node.findall(qn(self.ns['ome'], "ROIRef"))[index])
+
+        def get_roiref_count(self):
+            return len(self.node.findall(qn(self.ns['ome'], "ROIRef")))
+
+        def set_roiref_count(self, value):
+            '''Add or remove roirefs as needed'''
+            assert value > 0
+            if self.roiref_count > value:
+                roiref_nodes = self.node.find(qn(self.ns['ome'], "ROIRef"))
+                for roiref_node in roiref_nodes[value:]:
+                    self.node.remove(roiref_node)
+            while(self.roiref_count < value):
+                iteration = self.roiref_count - 1
+                new_roiref = OMEXML.ROIRef(ElementTree.SubElement(self.node, qn(self.ns['ome'], "ROIRef")))
+                new_roiref.set_ID("ROI:" + str(iteration))
+
+        roiref_count = property(get_roiref_count, set_roiref_count)
+
+    #-------------
+
     def image(self, index=0):
         '''Return an image node by index'''
         return self.Image(self.root_node.findall(qn(self.ns['ome'], "Image"))[index])
 
     class Channel(object):
         '''The OME/Image/Pixels/Channel element'''
+
         def __init__(self, node):
             self.node = node
             self.ns = get_namespaces(node)
 
         def get_ID(self):
             return self.node.get("ID")
+
         def set_ID(self, value):
             self.node.set("ID", value)
+
         ID = property(get_ID, set_ID)
 
         def get_Name(self):
             return self.node.get("Name")
+
         def set_Name(self, value):
             self.node.set("Name", value)
+
         Name = property(get_Name, set_Name)
 
         def get_SamplesPerPixel(self):
@@ -483,7 +539,69 @@ class OMEXML(object):
 
         def set_SamplesPerPixel(self, value):
             self.node.set("SamplesPerPixel", str(value))
+
         SamplesPerPixel = property(get_SamplesPerPixel, set_SamplesPerPixel)
+
+    #---------------------
+    # The following section was taken from the Allen Institute for Cell Science version of this file
+    # which can be found at https://github.com/AllenCellModeling/aicsimageio/blob/master/aicsimageio/vendor/omexml.py
+    class TiffData(object):
+        """The OME/Image/Pixels/TiffData element
+        <TiffData FirstC="0" FirstT="0" FirstZ="0" IFD="0" PlaneCount="1">
+            <UUID FileName="img40_1.ome.tif">urn:uuid:ef8af211-b6c1-44d4-97de-daca46f16346</UUID>
+        </TiffData>
+        For our purposes, there will be one TiffData per 2-dimensional image plane.
+        """
+
+        def __init__(self, node):
+            self.node = node
+            self.ns = get_namespaces(self.node)
+
+        def get_FirstZ(self):
+            '''The Z index of the plane'''
+            return get_int_attr(self.node, "FirstZ")
+
+        def set_FirstZ(self, value):
+            self.node.set("FirstZ", str(value))
+
+        FirstZ = property(get_FirstZ, set_FirstZ)
+
+        def get_FirstC(self):
+            '''The channel index of the plane'''
+            return get_int_attr(self.node, "FirstC")
+
+        def set_FirstC(self, value):
+            self.node.set("FirstC", str(value))
+
+        FirstC = property(get_FirstC, set_FirstC)
+
+        def get_FirstT(self):
+            '''The T index of the plane'''
+            return get_int_attr(self.node, "FirstT")
+
+        def set_FirstT(self, value):
+            self.node.set("FirstT", str(value))
+
+        FirstT = property(get_FirstT, set_FirstT)
+
+        def get_IFD(self):
+            '''plane index within tiff file'''
+            return get_int_attr(self.node, "IFD")
+
+        def set_IFD(self, value):
+            self.node.set("IFD", str(value))
+
+        IFD = property(get_IFD, set_IFD)
+
+        def get_PlaneCount(self):
+            '''How many planes in this TiffData. Should always be 1'''
+            return get_int_attr(self.node, "PlaneCount")
+
+        def set_PlaneCount(self, value):
+            self.node.set("PlaneCount", str(value))
+
+        PlaneCount = property(get_PlaneCount, set_PlaneCount)
+    #---------------------
 
     class Plane(object):
         '''The OME/Image/Pixels/Plane element
@@ -492,6 +610,7 @@ class OMEXML(object):
         has the Z, C and T indices of the plane and optionally has the
         X, Y, Z, exposure time and a relative time delta.
         '''
+
         def __init__(self, node):
             self.node = node
             self.ns = get_namespaces(self.node)
@@ -532,6 +651,16 @@ class OMEXML(object):
 
         DeltaT = property(get_DeltaT, set_DeltaT)
 
+        #-------------
+        # Added 3/9/2019 by Tom Fish
+        def set_ExposureTime(self, value):
+            self.node.set("ExposureTime", str(value))
+
+        def get_ExposureTime(self, value):
+            self.node.get("ExposureTime")
+
+        #-------------
+
         @property
         def ExposureTime(self):
             '''Units are seconds. Duration of acquisition????'''
@@ -570,6 +699,33 @@ class OMEXML(object):
 
         PositionZ = property(get_PositionZ, set_PositionZ)
 
+        #-------------
+        # Added 3/9/2019 by Tom Fish
+        def get_PositionXUnit(self):
+            self.node.get("PositionXUnit")
+
+        def set_PositionXUnit(self, value):
+            self.node.set("PositionXUnit", str(value))
+
+        PositionXUnit = property(get_PositionXUnit, set_PositionXUnit)
+
+        def get_PositionYUnit(self):
+            self.node.get("PositionYUnit")
+
+        def set_PositionYUnit(self, value):
+            self.node.set("PositionYUnit", str(value))
+
+        PositionYUnit = property(get_PositionYUnit, set_PositionYUnit)
+
+        def get_PositionZUnit(self):
+            self.node.get("PositionZUnit")
+
+        def set_PositionZUnit(self, value):
+            self.node.set("PositionZUnit", str(value))
+
+        PositionZUnit = property(get_PositionZUnit, set_PositionZUnit)
+
+        #-------------
     class Pixels(object):
         '''The OME/Image/Pixels element
 
@@ -578,14 +734,17 @@ class OMEXML(object):
         pixel data. It has the X, Y, Z, C, and T extents of the image
         and it specifies the channel interleaving and channel depth.
         '''
+
         def __init__(self, node):
             self.node = node
             self.ns = get_namespaces(self.node)
 
         def get_ID(self):
             return self.node.get("ID")
+
         def set_ID(self, value):
             self.node.set("ID", value)
+
         ID = property(get_ID, set_ID)
 
         def get_DimensionOrder(self):
@@ -596,8 +755,10 @@ class OMEXML(object):
             DO_XYZCT) to compare and set this.
             '''
             return self.node.get("DimensionOrder")
+
         def set_DimensionOrder(self, value):
             self.node.set("DimensionOrder", value)
+
         DimensionOrder = property(get_DimensionOrder, set_DimensionOrder)
 
         def get_PixelType(self):
@@ -612,61 +773,78 @@ class OMEXML(object):
         def get_PhysicalSizeXUnit(self):
             '''The unit of length of a pixel in X direction.'''
             return self.node.get("PhysicalSizeXUnit")
+
         def set_PhysicalSizeXUnit(self, value):
             self.node.set("PhysicalSizeXUnit", str(value))
+
         PhysicalSizeXUnit = property(get_PhysicalSizeXUnit, set_PhysicalSizeXUnit)
 
         def get_PhysicalSizeYUnit(self):
             '''The unit of length of a pixel in Y direction.'''
             return self.node.get("PhysicalSizeYUnit")
+
         def set_PhysicalSizeYUnit(self, value):
             self.node.set("PhysicalSizeYUnit", str(value))
+
         PhysicalSizeYUnit = property(get_PhysicalSizeYUnit, set_PhysicalSizeYUnit)
 
         def get_PhysicalSizeZUnit(self):
             '''The unit of length of a voxel in Z direction.'''
             return self.node.get("PhysicalSizeZUnit")
+
         def set_PhysicalSizeZUnit(self, value):
             self.node.set("PhysicalSizeZUnit", str(value))
+
         PhysicalSizeZUnit = property(get_PhysicalSizeZUnit, set_PhysicalSizeZUnit)
 
         def get_PhysicalSizeX(self):
             '''The length of a single pixel in X direction.'''
             return get_float_attr(self.node, "PhysicalSizeX")
+
         def set_PhysicalSizeX(self, value):
             self.node.set("PhysicalSizeX", str(value))
+
         PhysicalSizeX = property(get_PhysicalSizeX, set_PhysicalSizeX)
 
         def get_PhysicalSizeY(self):
             '''The length of a single pixel in Y direction.'''
             return get_float_attr(self.node, "PhysicalSizeY")
+
         def set_PhysicalSizeY(self, value):
             self.node.set("PhysicalSizeY", str(value))
+
         PhysicalSizeY = property(get_PhysicalSizeY, set_PhysicalSizeY)
 
         def get_PhysicalSizeZ(self):
             '''The size of a voxel in Z direction or None for 2D images.'''
             return get_float_attr(self.node, "PhysicalSizeZ")
+
         def set_PhysicalSizeZ(self, value):
             self.node.set("PhysicalSizeZ", str(value))
+
         PhysicalSizeZ = property(get_PhysicalSizeZ, set_PhysicalSizeZ)
 
         def set_PixelType(self, value):
             self.node.set("Type", value)
+
         PixelType = property(get_PixelType, set_PixelType)
 
         def get_SizeX(self):
             '''The dimensions of the image in the X direction in pixels'''
             return get_int_attr(self.node, "SizeX")
+
         def set_SizeX(self, value):
             self.node.set("SizeX", str(value))
+
         SizeX = property(get_SizeX, set_SizeX)
 
         def get_SizeY(self):
             '''The dimensions of the image in the Y direction in pixels'''
             return get_int_attr(self.node, "SizeY")
+
         def set_SizeY(self, value):
             self.node.set("SizeY", str(value))
+
         SizeY = property(get_SizeY, set_SizeY)
 
         def get_SizeZ(self):
@@ -675,6 +853,7 @@ class OMEXML(object):
 
         def set_SizeZ(self, value):
             self.node.set("SizeZ", str(value))
+
         SizeZ = property(get_SizeZ, set_SizeZ)
 
         def get_SizeT(self):
@@ -683,13 +862,16 @@ class OMEXML(object):
 
         def set_SizeT(self, value):
             self.node.set("SizeT", str(value))
+
         SizeT = property(get_SizeT, set_SizeT)
 
         def get_SizeC(self):
             '''The dimensions of the image in the C direction in pixels'''
             return get_int_attr(self.node, "SizeC")
+
         def set_SizeC(self, value):
             self.node.set("SizeC", str(value))
+
         SizeC = property(get_SizeC, set_SizeC)
 
         def get_channel_count(self):
@@ -760,8 +942,25 @@ class OMEXML(object):
             plane = self.node.findall(qn(self.ns['ome'], "Plane"))[index]
             return OMEXML.Plane(plane)
 
+        #-------------
+        # Added 3/9/2019 by Tom Fish
+        def set_tiffdata_count(self, value):
+            assert value >= 0
+            tiffdatas = self.node.findall(qn(self.ns['ome'], "TiffData"))
+            for td in tiffdatas:
+                self.node.remove(td)
+            for _ in range(0, value):
+                new_tiffdata = OMEXML.TiffData(
+                    ElementTree.SubElement(self.node, qn(self.ns['ome'], "TiffData")))
+
+        def TiffData(self, index=0):
+            data = self.node.findall(qn(self.ns['ome'], "TiffData"))[index]
+            return OMEXML.TiffData(data)
+        #-------------
+
     class Instrument(object):
         '''Representation of the OME/Instrument element'''
+
         def __init__(self, node):
             self.node = node
             self.ns = get_namespaces(self.node)
@@ -777,25 +976,26 @@ class OMEXML(object):
         @property
         def Detector(self):
             return OMEXML.Detector(self.node.find(qn(self.ns['ome'], "Detector")))
-        
+
         @property
         def Objective(self):
             return OMEXML.Objective(self.node.find(qn(self.ns['ome'], "Objective")))
 
-
     def instrument(self, index=0):
         return self.Instrument(self.root_node.findall(qn(self.ns['ome'], "Instrument"))[index])
 
-
     class Objective(object):
+
         def __init__(self, node):
             self.node = node
             self.ns = get_namespaces(self.node)
 
         def get_ID(self):
             return self.node.get("ID")
+
         def set_ID(self, value):
             self.node.set("ID", value)
+
         ID = property(get_ID, set_ID)
 
         def get_LensNA(self):
@@ -803,29 +1003,37 @@ class OMEXML(object):
 
         def set_LensNA(self, value):
             self.node.set("LensNA", value)
+
         LensNA = property(get_LensNA, set_LensNA)
 
         def get_NominalMagnification(self):
             return self.node.get("NominalMagnification")
+
         def set_NominalMagnification(self, value):
             self.node.set("NominalMagnification", value)
+
         NominalMagnification = property(get_NominalMagnification, set_NominalMagnification)
 
         def get_WorkingDistanceUnit(self):
             return get_int_attr(self.node, "WorkingDistanceUnit")
+
         def set_WorkingDistanceUnit(self, value):
             self.node.set("WorkingDistanceUnit", str(value))
+
         WorkingDistanceUnit = property(get_WorkingDistanceUnit, set_WorkingDistanceUnit)
-    
+
     class Detector(object):
+
         def __init__(self, node):
             self.node = node
             self.ns = get_namespaces(self.node)
 
         def get_ID(self):
             return self.node.get("ID")
+
         def set_ID(self, value):
             self.node.set("ID", value)
+
         ID = property(get_ID, set_ID)
 
         def get_Gain(self):
@@ -833,21 +1041,24 @@ class OMEXML(object):
 
         def set_Gain(self, value):
             self.node.set("Gain", value)
+
         Gain = property(get_Gain, set_Gain)
 
         def get_Model(self):
             return self.node.get("Model")
+
         def set_Model(self, value):
             self.node.set("Model", value)
+
         Model = property(get_Model, set_Model)
 
         def get_Type(self):
             return get_int_attr(self.node, "Type")
+
         def set_Type(self, value):
             self.node.set("Type", str(value))
+
         Type = property(get_Type, set_Type)
-
-
 
     class StructuredAnnotations(dict):
         '''The OME/StructuredAnnotations element
@@ -985,7 +1196,7 @@ class OMEXML(object):
             returns a dictionary of key to value
             '''
             d = {}
-            for annotation_id, (k,v) in self.iter_original_metadata():
+            for annotation_id, (k, v) in self.iter_original_metadata():
                 if annotation_id in ids:
                     d[k] = v
             return d
@@ -1000,6 +1211,7 @@ class OMEXML(object):
         Original metadata holds "vendor-specific" metadata including TIFF
         tag values.
         '''
+
         def __init__(self, sa):
             '''Initialized with the structured_annotations class instance'''
             self.sa = sa
@@ -1037,6 +1249,7 @@ class OMEXML(object):
 
     class PlatesDucktype(object):
         '''It looks like a list of plates'''
+
         def __init__(self, root):
             self.root = root
             self.ns = get_namespaces(self.root)
@@ -1054,7 +1267,7 @@ class OMEXML(object):
             for plate in self.root.iterfind(qn(self.ns['spw'], "Plate")):
                 yield OMEXML.Plate(plate)
 
-        def newPlate(self, name, plate_id = str(uuid.uuid4())):
+        def newPlate(self, name, plate_id=str(uuid.uuid4())):
             new_plate_node = ElementTree.SubElement(
                 self.root, qn(self.ns['spw'], "Plate"))
             new_plate = OMEXML.Plate(new_plate_node)
@@ -1068,6 +1281,7 @@ class OMEXML(object):
         This represents the plate element of the SPW schema:
         http://www.openmicroscopy.org/Schemas/SPW/2007-06/
         '''
+
         def __init__(self, node):
             self.node = node
             self.ns = get_namespaces(self.node)
@@ -1111,6 +1325,7 @@ class OMEXML(object):
         def set_ColumnNamingConvention(self, value):
             assert value in (NC_LETTER, NC_NUMBER)
             self.node.set("ColumnNamingConvention", value)
+
         ColumnNamingConvention = property(get_ColumnNamingConvention,
                                           set_ColumnNamingConvention)
 
@@ -1121,6 +1336,7 @@ class OMEXML(object):
         def set_RowNamingConvention(self, value):
             assert value in (NC_LETTER, NC_NUMBER)
             self.node.set("RowNamingConvention", value)
+
         RowNamingConvention = property(get_RowNamingConvention,
                                        set_RowNamingConvention)
 
@@ -1129,6 +1345,7 @@ class OMEXML(object):
 
         def set_WellOriginX(self, value):
             self.node.set("WellOriginX", str(value))
+
         WellOriginX = property(get_WellOriginX, set_WellOriginX)
 
         def get_WellOriginY(self):
@@ -1136,6 +1353,7 @@ class OMEXML(object):
 
         def set_WellOriginY(self, value):
             self.node.set("WellOriginY", str(value))
+
         WellOriginY = property(get_WellOriginY, set_WellOriginY)
 
         def get_Rows(self):
@@ -1162,17 +1380,19 @@ class OMEXML(object):
 
         def set_Description(self, text):
             make_text_node(self.node, self.ns['spw'], "Description", text)
+
         Description = property(get_Description, set_Description)
 
         def get_Well(self):
             '''The well dictionary / list'''
             return OMEXML.WellsDucktype(self)
+
         Well = property(get_Well)
 
         def get_well_name(self, well):
             '''Get a well's name, using the row and column convention'''
             result = "".join([
-                "%02d" % (i+1) if convention == NC_NUMBER
+                "%02d" % (i + 1) if convention == NC_NUMBER
                 else "ABCDEFGHIJKLMNOP"[i]
                 for i, convention
                 in ((well.Row, self.RowNamingConvention or NC_LETTER),
@@ -1194,6 +1414,7 @@ class OMEXML(object):
         If the ducktype is unable to parse a well name, it assumes you're
         using an ID.
         '''
+
         def __init__(self, plate):
             self.plate_node = plate.node
             self.plate = plate
@@ -1235,7 +1456,7 @@ class OMEXML(object):
                 well.node = w
                 yield self.plate.get_well_name(well)
 
-        def new(self, row, column, well_id = str(uuid.uuid4())):
+        def new(self, row, column, well_id=str(uuid.uuid4())):
             '''Create a new well at the given row and column
 
             row - index of well's row
@@ -1251,29 +1472,37 @@ class OMEXML(object):
             return well
 
     class Well(object):
+
         def __init__(self, node):
             self.node = node
 
         def get_Column(self):
             return get_int_attr(self.node, "Column")
+
         def set_Column(self, value):
             self.node.set("Column", str(value))
+
         Column = property(get_Column, set_Column)
 
         def get_Row(self):
             return get_int_attr(self.node, "Row")
+
         def set_Row(self, value):
             self.node.set("Row", str(value))
+
         Row = property(get_Row, set_Row)
 
         def get_ID(self):
             return self.node.get("ID")
+
         def set_ID(self, value):
             self.node.set("ID", value)
+
         ID = property(get_ID, set_ID)
 
         def get_Sample(self):
             return OMEXML.WellSampleDucktype(self.node)
+
         Sample = property(get_Sample)
 
         def get_ExternalDescription(self):
@@ -1305,6 +1534,7 @@ class OMEXML(object):
         things like:
         wellsamples[0:2]
         '''
+
         def __init__(self, well_node):
             self.well_node = well_node
             self.ns = get_namespaces(self.well_node)
@@ -1325,7 +1555,7 @@ class OMEXML(object):
             for s in all_samples:
                 yield OMEXML.WellSample(s)
 
-        def new(self, wellsample_id = str(uuid.uuid4()), index = None):
+        def new(self, wellsample_id=str(uuid.uuid4()), index=None):
             '''Create a new well sample
             '''
             if index is None:
@@ -1338,20 +1568,25 @@ class OMEXML(object):
 
     class WellSample(object):
         '''The WellSample is a location within a well'''
+
         def __init__(self, node):
             self.node = node
             self.ns = get_namespaces(self.node)
 
         def get_ID(self):
             return self.node.get("ID")
+
         def set_ID(self, value):
             self.node.set("ID", value)
+
         ID = property(get_ID, set_ID)
 
         def get_PositionX(self):
             return get_float_attr(self.node, "PositionX")
+
         def set_PositionX(self, value):
             self.node.set("PositionX", str(value))
+
         PositionX = property(get_PositionX, set_PositionX)
 
         def get_PositionY(self):
@@ -1359,6 +1594,7 @@ class OMEXML(object):
 
         def set_PositionY(self, value):
             self.node.set("PositionY", str(value))
+
         PositionY = property(get_PositionY, set_PositionY)
 
         def get_Timepoint(self):
@@ -1368,6 +1604,7 @@ class OMEXML(object):
             if isinstance(value, datetime.datetime):
                 value = value.isoformat()
             self.node.set("Timepoint", value)
+
         Timepoint = property(get_Timepoint, set_Timepoint)
 
         def get_Index(self):
@@ -1391,5 +1628,206 @@ class OMEXML(object):
             if ref is None:
                 ref = ElementTree.SubElement(self.node, qn(self.ns['spw'], "ImageRef"))
             ref.set("ID", value)
+
         ImageRef = property(get_ImageRef, set_ImageRef)
 
+    #-------------
+    # Added 9/9/2019 by Tom Fish
+    class ROIRef(object):
+
+        def __init__(self, node):
+            self.node = node
+            self.ns = get_namespaces(self.node)
+
+        def get_ID(self):
+            return self.node.get("ID")
+
+        def set_ID(self, value):
+            '''
+            ID will automatically be in the format "ROI:value"
+            and must match the ROI ID (which uses the same
+            formatting)
+            '''
+            self.node.set("ID", "ROI:" + str(value))
+
+        ID = property(get_ID, set_ID)
+
+    def get_roi_count(self):
+        return len(self.root_node.findall(qn(self.ns['ome'], "ROI")))
+
+    def set_roi_count(self, value):
+        '''Add or remove roi nodes as needed'''
+        assert value > 0
+        root = self.root_node
+        if self.roi_count > value:
+            roi_nodes = root.find(qn(self.ns['ome'], "ROI"))
+            for roi_node in roi_nodes[value:]:
+                root.remove(roi_node)
+        while(self.roi_count < value):
+            iteration = self.roi_count - 1
+
+            new_roi = self.ROI(ElementTree.SubElement(root, qn(self.ns['ome'], "ROI")))
+            new_roi.ID = str(iteration)
+            new_roi.Name = "Marker " + str(iteration)
+            new_Union = self.Union(
+                ElementTree.SubElement(new_roi.node, qn(self.ns['ome'], "Union")))
+            new_Rectangle = self.Rectangle(
+                ElementTree.SubElement(new_Union.node, qn(self.ns['ome'], "Rectangle")))
+            new_Rectangle.set_ID("Shape:" + str(iteration) + ":0")
+            new_Rectangle.set_TheZ(0)
+            new_Rectangle.set_TheC(0)
+            new_Rectangle.set_TheT(0)
+
+            new_Rectangle.set_StrokeColor(-16776961)  # Default = Red
+            new_Rectangle.set_StrokeWidth(20)
+            new_Rectangle.set_Text(str(iteration))
+            new_Rectangle.set_width(512)
+            new_Rectangle.set_height(512)
+            new_Rectangle.set_x(0)
+            new_Rectangle.set_y(0)
+
+    roi_count = property(get_roi_count, set_roi_count)
+
+    class ROI(object):
+
+        def __init__(self, node):
+            self.node = node
+            self.ns = get_namespaces(self.node)
+
+        def get_ID(self):
+            return self.node.get("ID")
+
+        def set_ID(self, value):
+            '''
+            ID will automatically be in the format "ROI:value"
+            and must match the ROIRef ID (which uses the same
+            formatting)
+            '''
+            self.node.set("ID", "ROI:" + str(value))
+
+        ID = property(get_ID, set_ID)
+
+        def get_name(self):
+            return self.node.get("Name")
+
+        def set_name(self, value):
+            self.node.set("Name", str(value))
+
+        Name = property(get_name, set_name)
+
+        @property
+        def Union(self):
+            '''The OME/ROI/Union element.'''
+            return OMEXML.Union(self.node.find(qn(self.ns['ome'], "Union")))
+
+    def roi(self, index=0):
+        '''Return an ROI node by index'''
+        return self.ROI(self.root_node.findall(qn(self.ns['ome'], "ROI"))[index])
+
+    class Union(object):
+
+        def __init__(self, node):
+            self.node = node
+            self.ns = get_namespaces(self.node)
+
+        def Rectangle(self, index=0):
+            '''The OME/ROI/Union element. Currenly only rectangle ROIs are available.'''
+            return OMEXML.Rectangle(self.node.find(qn(self.ns['ome'], "Rectangle")))
+
+    class Rectangle(object):
+
+        def __init__(self, node):
+            self.node = node
+            self.ns = get_namespaces(self.node)
+
+        def get_ID(self):
+            return self.node.get("ID")
+
+        def set_ID(self, value):
+            self.node.set("ID", str(value))
+
+        ID = property(get_ID, set_ID)
+
+        def get_StrokeColor(self):
+            return self.node.get("StrokeColor")
+
+        def set_StrokeColor(self, value):
+            self.node.set("StrokeColor", str(value))
+
+        StrokeColor = property(get_StrokeColor, set_StrokeColor)
+
+        def get_StrokeWidth(self):
+            return self.node.get("StrokeWidth")
+
+        def set_StrokeWidth(self, value):
+            self.node.set("StrokeWidth", str(value))
+
+        StrokeWidth = property(get_StrokeWidth, set_StrokeWidth)
+
+        def get_Text(self):
+            return self.node.get("Text")
+
+        def set_Text(self, value):
+            self.node.set("Text", str(value))
+
+        Text = property(get_Text, set_Text)
+
+        def get_height(self):
+            return self.node.get("Height")
+
+        def set_height(self, value):
+            self.node.set("Height", str(value))
+
+        Height = property(get_height, set_height)
+
+        def get_width(self):
+            return self.node.get("Width")
+
+        def set_width(self, value):
+            self.node.set("Width", str(value))
+
+        Width = property(get_width, set_width)
+
+        def get_x(self):
+            return self.node.get("X")
+
+        def set_x(self, value):
+            self.node.set("X", str(value))
+
+        X = property(get_x, set_x)
+
+        def get_y(self):
+            return self.node.get("Y")
+
+        def set_y(self, value):
+            self.node.set("Y", str(value))
+
+        Y = property(get_y, set_y)
+
+        def get_TheZ(self):
+            '''The Z index of the plane'''
+            return get_int_attr(self.node, "TheZ")
+
+        def set_TheZ(self, value):
+            self.node.set("TheZ", str(value))
+
+        TheZ = property(get_TheZ, set_TheZ)
+
+        def get_TheC(self):
+            '''The channel index of the plane'''
+            return get_int_attr(self.node, "TheC")
+
+        def set_TheC(self, value):
+            self.node.set("TheC", str(value))
+
+        TheC = property(get_TheC, set_TheC)
+
+        def get_TheT(self):
+            '''The T index of the plane'''
+            return get_int_attr(self.node, "TheT")
+
+        def set_TheT(self, value):
+            self.node.set("TheT", str(value))
+
+        TheT = property(get_TheT, set_TheT)
+    #-------------

--- a/tests/test_omexml.py
+++ b/tests/test_omexml.py
@@ -799,7 +799,7 @@ def test_14_10_get_exposure_time(tiff_xml):
     pixels = o.image(0).Pixels
     assert isinstance(pixels, bioformats.omexml.OMEXML.Pixels)
     plane = pixels.Plane(0)
-    assert plane.get_ExposureTime == 0.25
+    assert plane.get_ExposureTime() == 0.25
 
 
 def test_14_11_get_position_x(tiff_xml):

--- a/tests/test_omexml.py
+++ b/tests/test_omexml.py
@@ -799,7 +799,7 @@ def test_14_10_get_exposure_time(tiff_xml):
     pixels = o.image(0).Pixels
     assert isinstance(pixels, bioformats.omexml.OMEXML.Pixels)
     plane = pixels.Plane(0)
-    assert plane.ExposureTime == 0.25
+    assert plane.get_ExposureTime == 0.25
 
 
 def test_14_11_get_position_x(tiff_xml):


### PR DESCRIPTION
Added rectangle ROIs and TiffData to omexml.py.

ROI and ROIRefs can now be added, though only using the ROI shape Rectangle for now.

TiffData allows for proper use of Planes in n-dimensional tiffs by linking each plane to the corresponding IFD - this uses code from https://github.com/AllenCellModeling/aicsimageio/blob/master/aicsimageio/vendor/omexml.py