### PR TITLE
Generate version info from git tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@
 /dist
 \.eggs/
 \.idea/
+/\.pytest_cache/
 venv
+bioformats/_version.py

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,8 @@ setuptools.setup(
         "bioformats"
     ],
     url="http://github.com/CellProfiler/python-bioformats/",
-    version="4.0.5"
+    setup_requires = ['setuptools_scm'],
+    use_scm_version = {
+        "write_to": "bioformats/_version.py",
+    },
 )


### PR DESCRIPTION
Use the "setuptools_scm" package to automatically generate the version of the
package as well as the corresponding variable available in the code. This fixes
issue #86 while still leaving open the Sphinx part.

This fixes #147 